### PR TITLE
Fixing broken links on Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This repository is for anything related to organizing the [Design Systems Coalit
 We hope to host meetups every 6 to 8 weeks, if you'd like to get invovled, here's how:
 
 ### Offer to host a meetup
-We hope to host meetups regularly and are looking for companies with spaces that can accommodate 60—100 people. Read the [hosting guidelines](https://github.com/design-systems-coalition-NYC/meetup/hosting-guidelines.md) and if you'd like to host one of our meetups, [open a new issue](https://github.com/design-systems-coalition-NYC/meetup/issues/new?milestone=Meetup+venues+and+hosts).
+We hope to host meetups regularly and are looking for companies with spaces that can accommodate 60—100 people. Read the [hosting guidelines](http://designsystems.nyc/meetup/hosting-guidelines) and if you'd like to host one of our meetups, [open a new issue](https://github.com/design-systems-coalition-NYC/meetup/issues/new?milestone=Meetup+venues+and+hosts).
 
 ### Suggest speakers, or offer to speak yourself
-We want to hear from a diverse range of experiences. We welcome and will support first-time speakers, and people still new to design systems. If you think you have something interesting to share, or there are people or teams you'd like to hear from, [open an issue](https://github.com/design-systems-coalition-NYC/meetup/issues/new?milestone=Speaker+suggestions). Read our [speaker guidelines](https://github.com/design-systems-coalition-NYC/meetup/speaker-guidelines.md) for more details on what we're looking for and what to expect as a speaker.
+We want to hear from a diverse range of experiences. We welcome and will support first-time speakers, and people still new to design systems. If you think you have something interesting to share, or there are people or teams you'd like to hear from, [open an issue](https://github.com/design-systems-coalition-NYC/meetup/issues/new?milestone=Speaker+suggestions). Read our [speaker guidelines](http://designsystems.nyc/meetup/speaker-guidelines) for more details on what we're looking for and what to expect as a speaker.
 
 ### Suggest topic ideas
 At each meetup we have 3 speakers talk on a single topic related to design systems. If there's a topic you'd like to see covered in a future meetup please suggest your idea by [opening a new issue](https://github.com/design-systems-coalition-NYC/meetup/issues/new?milestone=Topic+ideas).


### PR DESCRIPTION
Hosting guidelines and speaker guidelines were not working.
They now link to: http://designsystems.nyc/meetup/hosting-guidelines and http://designsystems.nyc/meetup/speaker-guidelines
Similar to how the Code of Conduct link works